### PR TITLE
Documentation Fix: Link to latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This list gives an overview of the possibilities. For detailed information use t
 
 You need to have a JRE (minimum version 11) installed on your system. Also the java executable should be available in your PATH variable.
 
-1. Download latest build from [Releases](https://github.com/eu-digital-green-certificates/dgc-cli/releases/tag/latest)
+1. Download latest build from [Releases](https://github.com/eu-digital-green-certificates/dgc-cli/releases/latest)
 2. Extract ZIP-File to a path of your choice
 3. Add the Path to your PATH variable
 4. Check your installation


### PR DESCRIPTION
The link to the latest release is wrong. This PR fixes it.