### PR TITLE
Fix: Blank Spaces in Path to DGC-CLI Wrapper

### DIFF
--- a/src/wrapper/dgc.bat
+++ b/src/wrapper/dgc.bat
@@ -1,2 +1,2 @@
 @echo off
-java -jar %~dp0\dgc-cli.jar %*
+java -jar "%~dp0\dgc-cli.jar" %*


### PR DESCRIPTION
When DGC-CLI Wrapper was placed in a directory with a path with blank spaces it was not possible to start dgc-cli.
This new version of the wrapper fixes this.